### PR TITLE
Move design system packages to stable ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A template for building Alberta government **workspace applications** using the 
 
 ## Tech Stack
 
-- **React** 18.2 with TypeScript 5.3
+- **React** 19 with TypeScript 5.3
 - **Vite** 5.1 for fast development and builds
 - **React Router** 6.22 for routing
 - **GoA Design System 2.0** (`@abgov/react-components`, `@abgov/web-components`)
@@ -74,6 +74,10 @@ src/
 ```bash
 npm install
 ```
+
+### Keeping the design system current
+
+The `@abgov/*` packages use caret ranges, so `npm update` moves them to the latest stable release within their current major. A range never resolves a prerelease, so this cannot put you on a dev build. Moving to a new major is a deliberate upgrade you make yourself.
 
 ### Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,10 @@
       "name": "ui-components-react-template",
       "version": "0.0.0",
       "dependencies": {
-        "@abgov/design-tokens": "2.9.0",
-        "@abgov/react-components": "7.2.0-dev.13",
-        "@abgov/ui-components-common": "2.2.0-dev.5",
-        "@abgov/web-components": "2.2.0-dev.23",
+        "@abgov/design-tokens": "^2.12.6",
+        "@abgov/react-components": "^7.4.0",
+        "@abgov/ui-components-common": "^2.4.0",
+        "@abgov/web-components": "^2.4.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-error-boundary": "^4.1.2",
@@ -31,14 +31,14 @@
       }
     },
     "node_modules/@abgov/design-tokens": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.9.0.tgz",
-      "integrity": "sha512-Z3+wHUhLHCKJDXUBR0KpGBod5k5Jk+ehRNUC9J2OJZ0jcK3jF2/Ggeqhhze7+haiS0FdC1cikqT9vCnKZItU8Q=="
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/@abgov/design-tokens/-/design-tokens-2.12.6.tgz",
+      "integrity": "sha512-QeeFnzJv6O5d7daxrJdxQl6gaYgKXTGgGMl164CuOnzMg6r1fpVh7PSmqfUp3IXdNXXgE+m4eTb3IHXBrjTJ4g=="
     },
     "node_modules/@abgov/react-components": {
-      "version": "7.2.0-dev.13",
-      "resolved": "https://registry.npmjs.org/@abgov/react-components/-/react-components-7.2.0-dev.13.tgz",
-      "integrity": "sha512-s2n+m4kTfbIZRDULsOQYCFcZtsW3gE83O84sOLjs0rx1daRUMMYkFn9ogC/Rj2Qh3KwZa6iYfzkXt6jMBdpqyg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@abgov/react-components/-/react-components-7.4.0.tgz",
+      "integrity": "sha512-T4entbk5kFVLGoy2zcP5UfgFD4VpvrdCwEdR7m0WqEwRME3/ZlaWuJSOoccnA5PV1aewVUs8IV/Lg1LtzqvJJw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
@@ -47,15 +47,15 @@
       }
     },
     "node_modules/@abgov/ui-components-common": {
-      "version": "2.2.0-dev.5",
-      "resolved": "https://registry.npmjs.org/@abgov/ui-components-common/-/ui-components-common-2.2.0-dev.5.tgz",
-      "integrity": "sha512-VT6z1a/sLRYulUlNK4/tOg1nmZhkUW5Z5xWIekqq5C5DXGE7XUK+Da3Y1PQP0nmY+5QzYvwvFDqZvVcmLRavkg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@abgov/ui-components-common/-/ui-components-common-2.4.0.tgz",
+      "integrity": "sha512-mmM98wAPpTN/MxknIKYOmiCVE4lujeQJpqXIUzNxsgmRbGD2YlaWmNIM2q/RL0Okr4Ksbmq5k2tdlRJOmPUDXA==",
       "license": "Apache-2.0"
     },
     "node_modules/@abgov/web-components": {
-      "version": "2.2.0-dev.23",
-      "resolved": "https://registry.npmjs.org/@abgov/web-components/-/web-components-2.2.0-dev.23.tgz",
-      "integrity": "sha512-/qZ/QjxRDhDHHMBRGBAiSlePKMnC0gdaVSP9FCAQjT5OiuiTtXVZvOhNI1n5r8dSUGi5QdqIH9UO+tREUOEigA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@abgov/web-components/-/web-components-2.4.0.tgz",
+      "integrity": "sha512-QjWW5jAlRYNDkwVjel7t12HJfyXglRuafEjB7eie4UZBghbIxjvHCCkZ7JvCp35dDrmJ29HfgxJBYjD/Yb25fw==",
       "license": "Apache-2.0"
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "comment": "TODO: Replace local @abgov/* dependencies with npm registry packages before publishing this template",
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -13,10 +12,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@abgov/design-tokens": "2.9.0",
-    "@abgov/react-components": "7.2.0-dev.13",
-    "@abgov/ui-components-common": "2.2.0-dev.5",
-    "@abgov/web-components": "2.2.0-dev.23",
+    "@abgov/design-tokens": "^2.12.6",
+    "@abgov/react-components": "^7.4.0",
+    "@abgov/ui-components-common": "^2.4.0",
+    "@abgov/web-components": "^2.4.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-error-boundary": "^4.1.2",


### PR DESCRIPTION
Closes GovAlta/ui-components#4225

The four `@abgov` packages were pinned to exact versions while every other dependency in the same `package.json` used a range. Nothing maintains React's version and nothing needs to; the design system packages could not move without someone editing the file, which is why they are the ones that went stale. Three of the four were on dev builds, so every team using "Use this template" was starting on a prerelease.

This moves them to ranges on current stable:

```json
"@abgov/design-tokens": "^2.12.6",
"@abgov/react-components": "^7.4.0",
"@abgov/ui-components-common": "^2.4.0",
"@abgov/web-components": "^2.4.0"
```

Ranges rather than a version bump, because a bump fixes today and a range fixes the next time. Two things come free with it: ranges do not match prereleases, so the template cannot drift back onto the dev channel, and `^7` will not cross to `8`, so a person is involved only at a major.

The original reason for the dev pin has expired. It moved to the dev channel in May to pick up `GoabWorkspaceLayout` before it shipped, and `7.4.0` ships both that and the notification panel.

## What is in the diff

Three files, +25/-22.

- `package.json`, the four ranges, plus a stale `"comment"` field that said to replace the `@abgov` deps with registry packages before publishing the template. That is done, so the note went with it.
- `package-lock.json`, regenerated by `npm install`. The change set is only those four packages: version, resolved and integrity. No transitive dependencies moved.
- `README.md`, a short section telling forkers that `npm update` gets them to the latest stable within the current major and cannot land a prerelease. Also corrects the Tech Stack line, which said React 18.2 while `package.json` has pinned `^19.0.0` for some time.

Reproducibility is unchanged. `package-lock.json` stays committed and CI still runs `npm ci`, so the deployed build is exactly what was verified here. The range only takes effect when someone deliberately runs `npm update`.

## Verification

`npm run build:check` passes: no type errors, 821 modules, built in about 2s. Only the pre-existing chunk-size advisory.

The API surface across this span is additive. Diffing the shipped type declarations between `7.2.0-dev.13` and `7.4.0`: none removed, one added, 15 changed, and every change is a new optional prop or a type widening. The workspace layout declarations this template depends on (`workspace-layout`, `work-side-menu`, `work-side-notification-panel`) are byte-identical between the two versions.

`@abgov/web-components/index.css` is byte-identical too, so the visual delta comes entirely from `@abgov/design-tokens` `2.9.0` to `2.12.6`, where 47 tokens were added, 0 removed and 10 changed value.

**One of those 10 is visible in this template.** `--goa-dropdown-item-color-text` moved from `--goa-color-text-secondary` to `--goa-color-text-default`, so open dropdown menu items go from `#6f6f6f` to `#000000`, or 5.02:1 to 21.00:1 on white.

Comparing the deployed template against a local production build, across the dashboard, search, cases and notifications pages, the only other difference is sub-pixel letter-spacing on filter chips from `--goa-letter-spacing-xs`. No layout shift and no reflow. All 13 routes render, and the browser console is identical before and after: the same two pre-existing messages, nothing new.

Three changed tokens need an interaction to see and were not captured in a screenshot, so they are worth a look if you are opening things anyway. Modal footer padding goes from `0.5rem 2rem 2rem 2rem` to `1.5rem`, so a modal footer gains 16px on top and loses 8px on the sides and bottom. Error borders on text input and text area get thicker. The dropdown hover border gets thinner.

## Scope

React template only. The Angular template is a separate and larger job, noted in the issue so its omission is not read as an oversight.
